### PR TITLE
Added unique sprite folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ From inside the Louie subtheme directory, run `npm run build` for a clean build 
 
 Once you have finished theming the first page (home/standard) - take a screenshot and replace screenshot.png with a true representation of the theme.
 
-## Things to consider
-
-As this is a theme, you should remove the .git folder after cloning. Then, commit with the rest of your project. An easy way to do this is by running `npm run degit`.
-
 ## Todos
 
 - Test everything. Break somethings. Fix important things.

--- a/README.md
+++ b/README.md
@@ -2,25 +2,29 @@
 
 Louie uses Foundation 6.4+ and modern ES6+ coding practices for theme development.
 
+## Features
+
+- Drush subtheme create commands
+- eslint/es6 syntax built in
+- image optimization and svg sprite generation
+
 ## Installation
 
 Install into your custom themes directory.
 
-Run `npm install` from inside the Torsion directory.
+Run `npm install` from inside the Louie subtheme directory.
 
-From inside the Torsion directory, run `npm run build`. (`dev` command to come later.)
+From inside the Louie subtheme directory, run `npm run build` for a clean build or `npm start`/`npm run watch` to start the watch task.
 
 Once you have finished theming the first page (home/standard) - take a screenshot and replace screenshot.png with a true representation of the theme.
 
 ## Things to consider
 
-As this is a starter theme, you should remove the .git folder after cloning. Then, commit with the rest of your project. An easy way to do this is by running `npm run degit`.
+As this is a theme, you should remove the .git folder after cloning. Then, commit with the rest of your project. An easy way to do this is by running `npm run degit`.
 
 ## Todos
 
 - Test everything. Break somethings. Fix important things.
-- Fix `dev` scripts. Currently relies on BrowserSync. Need to run some tests to see how this breaks in development.
 - Add `clear cache` task for after build/dev runs.
 - Add Mannequin frontmatter to twig templates.
-- Add sprite generator
-- Add linting (AirBNB-style)
+- Refactor gulp into a better/modular format.

--- a/basket/BABY_LOUIE/package.json
+++ b/basket/BABY_LOUIE/package.json
@@ -5,7 +5,6 @@
   "main": "gulpfile.js",
   "scripts": {
     "postinstall": "find node_modules/ -name '*.info' -type f -delete",
-    "degit": "rm -r .git;",
     "start": "gulp",
     "build": "gulp build --production",
     "watch": "gulp watch",

--- a/basket/BABY_LOUIE/package.json
+++ b/basket/BABY_LOUIE/package.json
@@ -48,6 +48,7 @@
     "imagemin-jpeg-recompress": "^5.1.0",
     "imagemin-pngquant": "^5.0.1",
     "js-yaml": "^3.4.6",
+    "merge-stream": "^1.0.1",
     "rimraf": "^2.4.3",
     "vinyl-named": "^1.1.0",
     "webpack": "^2.6.1",


### PR DESCRIPTION
Added unique sprite folders, refactored code a touch, and changed readme and bit.

**This has a bit of new functionality.** If you just have sprites in the root `src/sprites/` folder, move them into a named folder: `src/sprites/icons/` or something else. You can now have multiple directories for different kinds of sprites. Not a fan of how the config is now buried in the function, but it has to be for now.

Also, cleaned up code to template literals (the backticks) and changed the readme slightly.